### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default Owners
+*       @OpenMPDK/dss-default-reviewers


### PR DESCRIPTION
## Description
Add `.github/CODEOWNERS` so that there are default reviewers for this project

## Motivation and Context
This change allows default reviewers to be automatically assigned when a PR is opened.

## Regression
Not a regression.

## How Has This Been Tested?
This change has not been tested.

## Types of changes
N/A

## Checklist:
N/A