### PR TITLE
Direct RDMA transfer support of value buffer bypassing object store

### DIFF
--- a/cmd/bucket-handlers-listobjects.go
+++ b/cmd/bucket-handlers-listobjects.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"net/http"
 	"strings"
-        "fmt"
+        //"fmt"
 	"github.com/gorilla/mux"
 	"github.com/minio/minio/cmd/crypto"
 	"github.com/minio/minio/cmd/logger"
@@ -91,7 +91,7 @@ func (api objectAPIHandlers) ListObjectsV2Handler(w http.ResponseWriter, r *http
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(errCode), r.URL, guessIsBrowserReq(r))
 		return
 	}
-        fmt.Println("$$ ListObject V2 called = ", bucket, prefix)
+        //fmt.Println("$$ ListObject V2 called = ", bucket, prefix)
 	// Validate the query params before beginning to serve the request.
 	// fetch-owner is not validated since it is a boolean
 	if s3Error := validateListObjectsArgs(prefix, token, delimiter, encodingType, maxKeys); s3Error != ErrNone {
@@ -171,15 +171,15 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Error), r.URL, guessIsBrowserReq(r))
 		return
 	}
-        var org_prefix string = prefix
-        key_slices := strings.Split(prefix, globalRddSeparator)
-        if (len(key_slices) == 1) {
-          prefix = key_slices[0]
-        } else {
-          prefix = key_slices[3]
-        }
+        //var org_prefix string = prefix
+        //key_slices := strings.Split(prefix, globalRddSeparator)
+        //if (len(key_slices) == 1) {
+          //prefix = key_slices[0]
+        //} else {
+          //prefix = key_slices[3]
+        //}
 
-        fmt.Println("$$$$ ListObject V1 called = ", bucket, prefix)
+        //fmt.Println("$$$$ ListObject V1 called = ", bucket, prefix)
 	// Validate all the query params before beginning to serve the request.
 	if s3Error := validateListObjectsArgs(prefix, marker, delimiter, encodingType, maxKeys); s3Error != ErrNone {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Error), r.URL, guessIsBrowserReq(r))
@@ -195,7 +195,7 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 	// On success would return back ListObjectsInfo object to be
 	// marshaled into S3 compatible XML header.
 	listObjectsInfo, err := listObjects(ctx, bucket, prefix, marker, delimiter, maxKeys)
-        fmt.Println("$$$$ listObjectsInfo, err = ", listObjectsInfo, err)
+        //fmt.Println("$$$$ listObjectsInfo, err = ", listObjectsInfo, err)
 	if err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
@@ -221,9 +221,9 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 			}
 		}
 	}
-        fmt.Println("$$$$ org_prefix = ", org_prefix)
-	response := generateListObjectsV1Response(bucket, org_prefix, marker, delimiter, encodingType, maxKeys, listObjectsInfo)
-        fmt.Println("$$$$ list response = ", response)
+        //fmt.Println("$$$$ org_prefix = ", org_prefix)
+	response := generateListObjectsV1Response(bucket, prefix, marker, delimiter, encodingType, maxKeys, listObjectsInfo)
+        //fmt.Println("$$$$ list response = ", response)
     	// Write success response.
 	writeSuccessResponseXML(w, encodeResponse(response))
 }

--- a/cmd/bucket-handlers-listobjects.go
+++ b/cmd/bucket-handlers-listobjects.go
@@ -19,7 +19,7 @@ package cmd
 import (
 	"net/http"
 	"strings"
-
+        "fmt"
 	"github.com/gorilla/mux"
 	"github.com/minio/minio/cmd/crypto"
 	"github.com/minio/minio/cmd/logger"
@@ -91,7 +91,7 @@ func (api objectAPIHandlers) ListObjectsV2Handler(w http.ResponseWriter, r *http
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(errCode), r.URL, guessIsBrowserReq(r))
 		return
 	}
-
+        fmt.Println("$$ ListObject V2 called = ", bucket, prefix)
 	// Validate the query params before beginning to serve the request.
 	// fetch-owner is not validated since it is a boolean
 	if s3Error := validateListObjectsArgs(prefix, token, delimiter, encodingType, maxKeys); s3Error != ErrNone {
@@ -171,7 +171,15 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Error), r.URL, guessIsBrowserReq(r))
 		return
 	}
+        var org_prefix string = prefix
+        key_slices := strings.Split(prefix, "-rdd-")
+        if (len(key_slices) == 1) {
+          prefix = key_slices[0]
+        } else {
+          prefix = key_slices[3]
+        }
 
+        fmt.Println("$$$$ ListObject V1 called = ", bucket, prefix)
 	// Validate all the query params before beginning to serve the request.
 	if s3Error := validateListObjectsArgs(prefix, marker, delimiter, encodingType, maxKeys); s3Error != ErrNone {
 		writeErrorResponse(ctx, w, errorCodes.ToAPIErr(s3Error), r.URL, guessIsBrowserReq(r))
@@ -187,6 +195,7 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 	// On success would return back ListObjectsInfo object to be
 	// marshaled into S3 compatible XML header.
 	listObjectsInfo, err := listObjects(ctx, bucket, prefix, marker, delimiter, maxKeys)
+        fmt.Println("$$$$ listObjectsInfo, err = ", listObjectsInfo, err)
 	if err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
@@ -212,8 +221,9 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 			}
 		}
 	}
-	response := generateListObjectsV1Response(bucket, prefix, marker, delimiter, encodingType, maxKeys, listObjectsInfo)
-
-	// Write success response.
+        fmt.Println("$$$$ org_prefix = ", org_prefix)
+	response := generateListObjectsV1Response(bucket, org_prefix, marker, delimiter, encodingType, maxKeys, listObjectsInfo)
+        fmt.Println("$$$$ list response = ", response)
+    	// Write success response.
 	writeSuccessResponseXML(w, encodeResponse(response))
 }

--- a/cmd/bucket-handlers-listobjects.go
+++ b/cmd/bucket-handlers-listobjects.go
@@ -172,7 +172,7 @@ func (api objectAPIHandlers) ListObjectsV1Handler(w http.ResponseWriter, r *http
 		return
 	}
         var org_prefix string = prefix
-        key_slices := strings.Split(prefix, "-rdd-")
+        key_slices := strings.Split(prefix, globalRddSeparator)
         if (len(key_slices) == 1) {
           prefix = key_slices[0]
         } else {

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -118,6 +118,7 @@ func (api objectAPIHandlers) GetBucketLocationHandler(w http.ResponseWriter, r *
 	encodedSuccessResponse := encodeResponse(LocationResponse{})
 	// Get current region.
 	region := globalServerConfig.GetRegion()
+        fmt.Println("Global region, minio region = ", region, globalMinioDefaultRegion)
 	if region != globalMinioDefaultRegion {
 		encodedSuccessResponse = encodeResponse(LocationResponse{
 			Location: region,

--- a/cmd/bucket-handlers.go
+++ b/cmd/bucket-handlers.go
@@ -118,7 +118,7 @@ func (api objectAPIHandlers) GetBucketLocationHandler(w http.ResponseWriter, r *
 	encodedSuccessResponse := encodeResponse(LocationResponse{})
 	// Get current region.
 	region := globalServerConfig.GetRegion()
-        fmt.Println("Global region, minio region = ", region, globalMinioDefaultRegion)
+        //fmt.Println("Global region, minio region = ", region, globalMinioDefaultRegion)
 	if region != globalMinioDefaultRegion {
 		encodedSuccessResponse = encodeResponse(LocationResponse{
 			Location: region,

--- a/cmd/debug-storage.go
+++ b/cmd/debug-storage.go
@@ -196,3 +196,22 @@ func (d *debugStorage) ReadAndCopy(volume string, filePath string, writer io.Wri
         return err
 }
 
+func (d *debugStorage) ReadRDDWay(volume string, filePath string, remoteAddress uint64, valueLen uint64, 
+                                  rKey uint32, rQhandle uint16) (err error) {
+        err = d.s.ReadRDDWay(volume, filePath, remoteAddress, valueLen, rKey, rQhandle)
+        if d.enable {
+                fmt.Printf("%s: ReadRDDWay(%s, %s) (%s)\n", d.path, volume, filePath, errStr(err))
+        }
+        return err
+}
+
+func (d *debugStorage) AddRDDParam(remoteClientId uint64, NQNId string, rQhandle uint16) (err error) {
+        err = d.s.AddRDDParam(remoteClientId, NQNId, rQhandle)
+        if d.enable {
+                fmt.Printf("%s: AddRDDParam(%s, %d) (%s)\n", d.path, NQNId, rQhandle, errStr(err))
+        }
+        return err
+}
+
+
+

--- a/cmd/debug-storage.go
+++ b/cmd/debug-storage.go
@@ -197,15 +197,15 @@ func (d *debugStorage) ReadAndCopy(volume string, filePath string, writer io.Wri
 }
 
 func (d *debugStorage) ReadRDDWay(volume string, filePath string, remoteAddress uint64, valueLen uint64, 
-                                  rKey uint32, rQhandle uint16) (err error) {
-        err = d.s.ReadRDDWay(volume, filePath, remoteAddress, valueLen, rKey, rQhandle)
+                                  rKey uint32, remoteClientId string) (err error) {
+        err = d.s.ReadRDDWay(volume, filePath, remoteAddress, valueLen, rKey, remoteClientId) 
         if d.enable {
                 fmt.Printf("%s: ReadRDDWay(%s, %s) (%s)\n", d.path, volume, filePath, errStr(err))
         }
         return err
 }
 
-func (d *debugStorage) AddRDDParam(remoteClientId uint64, NQNId string, rQhandle uint16) (err error) {
+func (d *debugStorage) AddRDDParam(remoteClientId string, NQNId string, rQhandle uint16) (err error) {
         err = d.s.AddRDDParam(remoteClientId, NQNId, rQhandle)
         if d.enable {
                 fmt.Printf("%s: AddRDDParam(%s, %d) (%s)\n", d.path, NQNId, rQhandle, errStr(err))

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -178,16 +178,18 @@ var (
         globalOptimizedMetaReader bool 
         globalMetaOptNoStat bool 
         globalNoEC bool 
+        globalNoRDD bool = false 
         globalNoReadVerifyList bool 
         globalECBlockSizeKB int64 
         globalInstanceHost string
+        globalRddSeparator string
         globalTotalGetQD uint64
         globalTotalECReqQD uint64
         globalTotalHeadObjQD uint64
         globalTotalHeadIOCount uint64
         globalTotalGetIOCount uint64
         globalIsStopping bool = false
-        gIsRDDQHandleSet bool = true
+        gIsRDDQHandleSet bool = false
 
 	// Global server's network statistics
 	globalConnStats = newConnStats()

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -187,6 +187,7 @@ var (
         globalTotalHeadIOCount uint64
         globalTotalGetIOCount uint64
         globalIsStopping bool = false
+        gIsRDDQHandleSet bool = true
 
 	// Global server's network statistics
 	globalConnStats = newConnStats()

--- a/cmd/kv-emulator.go
+++ b/cmd/kv-emulator.go
@@ -68,3 +68,18 @@ func (k *KVEmulator) nkv_close() error {
         return nil
 }
 
+func (k *KVEmulator) Get_Rdd(keyStr string, remoteAddress uint64, valueLen uint64, rKey uint32, rQhandle uint16) error {
+
+       return nil
+}
+
+func (k *KVEmulator) Set_Rdd_Param(remoteClientId uint64, NQNId string, rQhandle uint16) (err error) {
+
+       return nil
+}
+
+func (k *KVEmulator) Clear_Rdd_Param(remoteClientId uint64) (err error) {
+
+      return nil
+}
+

--- a/cmd/kv-emulator.go
+++ b/cmd/kv-emulator.go
@@ -68,17 +68,17 @@ func (k *KVEmulator) nkv_close() error {
         return nil
 }
 
-func (k *KVEmulator) Get_Rdd(keyStr string, remoteAddress uint64, valueLen uint64, rKey uint32, rQhandle uint16) error {
+func (k *KVEmulator) Get_Rdd(keyStr string, remoteAddress uint64, valueLen uint64, rKey uint32, remoteClientId string) error {
 
        return nil
 }
 
-func (k *KVEmulator) Set_Rdd_Param(remoteClientId uint64, NQNId string, rQhandle uint16) (err error) {
+func (k *KVEmulator) Set_Rdd_Param(remoteClientId string, NQNId string, rQhandle uint16) (err error) {
 
        return nil
 }
 
-func (k *KVEmulator) Clear_Rdd_Param(remoteClientId uint64) (err error) {
+func (k *KVEmulator) Clear_Rdd_Param(remoteClientId string) (err error) {
 
       return nil
 }

--- a/cmd/kv-interface.go
+++ b/cmd/kv-interface.go
@@ -10,6 +10,9 @@ import (
 type KVInterface interface {
 	Put(keyStr string, value []byte) error
 	Get(keyStr string, value []byte) ([]byte, error)
+	Get_Rdd(keyStr string, remoteAddress uint64, valueLen uint64, rKey uint32, rQhandle uint16) error
+        Set_Rdd_Param(remoteClientId uint64, NQNId string, rQhandle uint16) (err error)
+        Clear_Rdd_Param(remoteClientId uint64) (err error)
 	Delete(keyStr string) error
 	List(prefix string, buf []byte) ([]string, error)
 	DiskInfo() (DiskInfo, error)

--- a/cmd/kv-interface.go
+++ b/cmd/kv-interface.go
@@ -10,9 +10,9 @@ import (
 type KVInterface interface {
 	Put(keyStr string, value []byte) error
 	Get(keyStr string, value []byte) ([]byte, error)
-	Get_Rdd(keyStr string, remoteAddress uint64, valueLen uint64, rKey uint32, rQhandle uint16) error
-        Set_Rdd_Param(remoteClientId uint64, NQNId string, rQhandle uint16) (err error)
-        Clear_Rdd_Param(remoteClientId uint64) (err error)
+	Get_Rdd(keyStr string, remoteAddress uint64, valueLen uint64, rKey uint32, remoteClientId string) error
+        Set_Rdd_Param(remoteClientId string, NQNId string, rQhandle uint16) (err error)
+        Clear_Rdd_Param(remoteClientId string) (err error)
 	Delete(keyStr string) error
 	List(prefix string, buf []byte) ([]string, error)
 	DiskInfo() (DiskInfo, error)

--- a/cmd/kv-storage.go
+++ b/cmd/kv-storage.go
@@ -1475,3 +1475,30 @@ func (k *KVStorage) UpdateStats() error {
   k.kv.UpdateStats()
   return nil
 }
+
+func (k *KVStorage) ReadRDDWay(volume string, filePath string, remoteAddress uint64, valueLen uint64,
+                               rKey uint32, rQhandle uint16) (err error) {
+
+  nskey := pathJoin(volume, filePath)
+  if !strings.HasSuffix(nskey, xlMetaJSONFile) || !strings.Contains(nskey, ".minio.sys") {
+    nskey = k.DataKey(nskey)
+  }
+  err_kv := k.kv.Get_Rdd(nskey, remoteAddress, valueLen, rKey, rQhandle)
+  if err_kv != nil {
+    return err_kv
+  }
+  return nil
+
+}
+
+func (k *KVStorage) AddRDDParam(remoteClientId uint64, NQNId string, rQhandle uint16) (err error) {
+
+  err_kv := k.kv.Set_Rdd_Param(remoteClientId, NQNId, rQhandle)
+  if err_kv != nil {
+    return err_kv
+  }
+
+  return nil
+
+}
+

--- a/cmd/kv-storage.go
+++ b/cmd/kv-storage.go
@@ -1477,13 +1477,13 @@ func (k *KVStorage) UpdateStats() error {
 }
 
 func (k *KVStorage) ReadRDDWay(volume string, filePath string, remoteAddress uint64, valueLen uint64,
-                               rKey uint32, rQhandle uint16) (err error) {
+                               rKey uint32, remoteClientId string) (err error) {
 
   nskey := pathJoin(volume, filePath)
   if !strings.HasSuffix(nskey, xlMetaJSONFile) || !strings.Contains(nskey, ".minio.sys") {
     nskey = k.DataKey(nskey)
   }
-  err_kv := k.kv.Get_Rdd(nskey, remoteAddress, valueLen, rKey, rQhandle)
+  err_kv := k.kv.Get_Rdd(nskey, remoteAddress, valueLen, rKey, remoteClientId)
   if err_kv != nil {
     return err_kv
   }
@@ -1491,7 +1491,7 @@ func (k *KVStorage) ReadRDDWay(volume string, filePath string, remoteAddress uin
 
 }
 
-func (k *KVStorage) AddRDDParam(remoteClientId uint64, NQNId string, rQhandle uint16) (err error) {
+func (k *KVStorage) AddRDDParam(remoteClientId string, NQNId string, rQhandle uint16) (err error) {
 
   err_kv := k.kv.Set_Rdd_Param(remoteClientId, NQNId, rQhandle)
   if err_kv != nil {

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -538,6 +538,7 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 // -----------
 // The HEAD operation retrieves metadata from an object without returning the object itself.
 func (api objectAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.Request) {
+        fmt.Println("@@@@@@@@ HeadObjectHandler called....")
 	ctx := newContext(r, w, "HeadObject")
 
 	defer logger.AuditLog(w, r, "HeadObject", mustGetClaimsFromToken(r))
@@ -629,6 +630,7 @@ func (api objectAPIHandlers) HeadObjectHandler(w http.ResponseWriter, r *http.Re
         }
 
 	objInfo, err := getObjectInfo(ctx, bucket, object, opts)
+        fmt.Println("############objInfo.UserDefined, X-Amz-Meta-Rdd_param = " , objInfo.UserDefined, objInfo.UserDefined["X-Amz-Meta-Rdd_param"]) 
 	if err != nil {
 		writeErrorResponseHeadersOnly(w, toAPIError(ctx, err))
                 if (track_minio_stats) {
@@ -1371,6 +1373,7 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	// get gateway encryption options
 	var opts ObjectOptions
 	opts, err = putOpts(ctx, r, bucket, object, metadata)
+        //fmt.Println("@@@ putOpts= ", opts)
 	if err != nil {
 		writeErrorResponseHeadersOnly(w, toAPIError(ctx, err))
 		return

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -1416,12 +1416,12 @@ func (s *posix) ReadAndCopy(volume string, filePath string, writer io.Writer) (e
 }
 
 func (s *posix) ReadRDDWay(volume string, filePath string, remoteAddress uint64, valueLen uint64,
-                               rKey uint32, rQhandle uint16) (err error) {
+                               rKey uint32, remoteClientId string) (err error) {
 
         return nil
 }
 
-func (s *posix) AddRDDParam(remoteClientId uint64, NQNId string, rQhandle uint16) (err error) {
+func (s *posix) AddRDDParam(remoteClientId string, NQNId string, rQhandle uint16) (err error) {
 
   return nil
 }

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -1415,3 +1415,15 @@ func (s *posix) ReadAndCopy(volume string, filePath string, writer io.Writer) (e
   return nil
 }
 
+func (s *posix) ReadRDDWay(volume string, filePath string, remoteAddress uint64, valueLen uint64,
+                               rKey uint32, rQhandle uint16) (err error) {
+
+        return nil
+}
+
+func (s *posix) AddRDDParam(remoteClientId uint64, NQNId string, rQhandle uint16) (err error) {
+
+  return nil
+}
+
+

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -58,8 +58,8 @@ type StorageAPI interface {
 	// Read all.
 	ReadAll(volume string, path string) (buf []byte, err error)
 	ReadAndCopy(volume string, path string, writer io.Writer) (err error)
-        ReadRDDWay(volume string, filePath string, remoteAddress uint64, valueLen uint64, rKey uint32, rQhandle uint16) (err error)
-        AddRDDParam(remoteClientId uint64, NQNId string, rQhandle uint16) (err error)
+        ReadRDDWay(volume string, filePath string, remoteAddress uint64, valueLen uint64, rKey uint32, remoteClientId string) (err error)
+        AddRDDParam(remoteClientId string, NQNId string, rQhandle uint16) (err error)
 }
 
 // storageReader is an io.Reader view of a disk

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -58,6 +58,8 @@ type StorageAPI interface {
 	// Read all.
 	ReadAll(volume string, path string) (buf []byte, err error)
 	ReadAndCopy(volume string, path string, writer io.Writer) (err error)
+        ReadRDDWay(volume string, filePath string, remoteAddress uint64, valueLen uint64, rKey uint32, rQhandle uint16) (err error)
+        AddRDDParam(remoteClientId uint64, NQNId string, rQhandle uint16) (err error)
 }
 
 // storageReader is an io.Reader view of a disk

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -398,12 +398,12 @@ func (client *storageRESTClient) ReadAndCopy(volume string, filePath string, wri
 }
 
 func (client *storageRESTClient) ReadRDDWay(volume string, filePath string, remoteAddress uint64, valueLen uint64,
-                               rKey uint32, rQhandle uint16) (err error) {
+                               rKey uint32, remoteClientId string) (err error) {
 
   return nil
 }
 
-func (client *storageRESTClient) AddRDDParam(remoteClientId uint64, NQNId string, rQhandle uint16) (err error) {
+func (client *storageRESTClient) AddRDDParam(remoteClientId string, NQNId string, rQhandle uint16) (err error) {
 
   return nil
 }

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -397,6 +397,16 @@ func (client *storageRESTClient) ReadAndCopy(volume string, filePath string, wri
   return nil
 }
 
+func (client *storageRESTClient) ReadRDDWay(volume string, filePath string, remoteAddress uint64, valueLen uint64,
+                               rKey uint32, rQhandle uint16) (err error) {
+
+  return nil
+}
+
+func (client *storageRESTClient) AddRDDParam(remoteClientId uint64, NQNId string, rQhandle uint16) (err error) {
+
+  return nil
+}
 
 
 // Gets peer storage server's instanceID - to be used with every REST call for validation.

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -523,6 +523,18 @@ func newXLSets(endpoints EndpointList, format *formatXLV3, setCount int, drivesP
         }
         fmt.Println("### Max KV object size supported = ###", globalMaxKVObject)
 
+        globalNoRDD = false
+        if os.Getenv("MINIO_DISABLE_RDD") != "" {
+          fmt.Println("### Setting up Minio without RDD support.. ###")
+          globalNoRDD = true
+        }
+
+        globalRddSeparator = "-rdd-"
+        if v := os.Getenv("MINIO_RDD_KEY_SEPARATOR"); v != "" {
+          globalRddSeparator = v
+        }
+        fmt.Printf("### RDD Key separator  = %s\n", globalRddSeparator)
+
         globalDummy_read = -1
        
 	return s, nil

--- a/cmd/xl-v1-bucket.go
+++ b/cmd/xl-v1-bucket.go
@@ -182,6 +182,7 @@ func (xl xlObjects) GetBucketInfo(ctx context.Context, bucket string) (bi Bucket
 	if err != nil {
 		return bi, toObjectErr(err, bucket)
 	}
+        //fmt.Println("### GetBucketInfo returning::", bucketInfo)
 	return bucketInfo, nil
 }
 

--- a/cmd/xl-v1-metadata.go
+++ b/cmd/xl-v1-metadata.go
@@ -26,6 +26,7 @@ import (
 	"sort"
 	"sync"
 	"time"
+        //"fmt"
 	"github.com/minio/minio/cmd/logger"
 )
 
@@ -433,6 +434,7 @@ func deleteXLMetdata(ctx context.Context, disk StorageAPI, bucket, prefix string
 
 // writeXLMetadata - writes `xl.json` to a single disk.
 func writeXLMetadata(ctx context.Context, disk StorageAPI, bucket, prefix string, xlMeta xlMetaV1) error {
+        //fmt.Println("xlMeta during write = ", xlMeta)
 	jsonFile := path.Join(prefix, xlMetaJSONFile)
 
 	// Marshal json.

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -25,6 +25,8 @@ import (
 	"strconv"
 	"sync"
         "fmt"
+        "strings"
+        "errors"
         "hash/crc32"
         //"runtime/debug"
 	"github.com/minio/minio/cmd/logger"
@@ -149,7 +151,15 @@ func (xl xlObjects) CopyObject(ctx context.Context, srcBucket, srcObject, dstBuc
 
 // GetObjectNInfo - returns object info and an object
 // Read(Closer). When err != nil, the returned reader is always nil.
-func (xl xlObjects) GetObjectNInfo(ctx context.Context, bucket, object string, rs *HTTPRangeSpec, h http.Header, lockType LockType, opts ObjectOptions) (gr *GetObjectReader, err error) {
+func (xl xlObjects) GetObjectNInfo(ctx context.Context, bucket, object_key string, rs *HTTPRangeSpec, h http.Header, 
+                                   lockType LockType, opts ObjectOptions) (gr *GetObjectReader, err error) {
+        var object string
+        key_slices := strings.Split(object_key, "-rdd-")
+        if (len(key_slices) == 1) {
+          object = key_slices[0]
+        } else {
+          object = key_slices[4]
+        }
 	var nsUnlocker = func() {}
         //debug.PrintStack()
         //fmt.Println("@@@@ GetObjectNInfo called ::", bucket, object );
@@ -195,6 +205,7 @@ func (xl xlObjects) GetObjectNInfo(ctx context.Context, bucket, object string, r
 	//var objInfo ObjectInfo
 	//objInfo, err = xl.getObjectInfo(ctx, bucket, object)
 	objInfo, metaArr, xlMeta, errs, err_obj := xl.getObjectInfoVerbose(ctx, bucket, object)
+        //fmt.Println("objInfo.UserDefined = " , objInfo.UserDefined)
 	if err_obj != nil {
 		nsUnlocker()
 		return nil, toObjectErr(err_obj, bucket, object)
@@ -209,7 +220,8 @@ func (xl xlObjects) GetObjectNInfo(ctx context.Context, bucket, object string, r
 	//pr, _ := io.Pipe()
 	go func() {
 		//err := xl.getObject(ctx, bucket, object, off, length, pw, "", opts)
-		err := xl.getObjectNoMeta(ctx, bucket, object, off, length, pw, "", opts, metaArr, xlMeta, errs)
+		//err := xl.getObjectNoMeta(ctx, bucket, object, off, length, pw, objInfo.ETag, opts, metaArr, xlMeta, errs, key_slices)
+		err := xl.getObjectNoMeta(ctx, bucket, object, off, length, pw, "", opts, metaArr, xlMeta, errs, key_slices)
                 //block := make([]byte, length)
                 //_, err := io.Copy(pw, bytes.NewReader(block))
                 
@@ -231,16 +243,24 @@ func (xl xlObjects) GetObjectNInfo(ctx context.Context, bucket, object string, r
 func (xl xlObjects) GetObject(ctx context.Context, bucket, object string, startOffset int64, length int64, writer io.Writer, etag string, opts ObjectOptions) error {
 	// Lock the object before reading.
         //fmt.Println("!!!! GetObject called ::", bucket, object );
-	objectLock := xl.nsMutex.NewNSLock(bucket, object)
-	if err := objectLock.GetRLock(globalObjectTimeout); err != nil {
+        if !globalNolock_read {
+	  objectLock := xl.nsMutex.NewNSLock(bucket, object)
+	  if err := objectLock.GetRLock(globalObjectTimeout); err != nil {
 		return err
-	}
-	defer objectLock.RUnlock()
+	  }
+	  defer objectLock.RUnlock()
+        }
 	return xl.getObject(ctx, bucket, object, startOffset, length, writer, etag, opts)
 }
 
-func (xl xlObjects) getObjectNoMeta(ctx context.Context, bucket, object string, startOffset int64, length int64, writer io.Writer, etag string, opts ObjectOptions, metaArr []xlMetaV1, xlMeta xlMetaV1, errs []error) error {
+func (xl xlObjects) getObjectNoMeta(ctx context.Context, bucket, object string, startOffset int64, length int64, writer io.Writer, etag string, opts ObjectOptions, metaArr []xlMetaV1, xlMeta xlMetaV1, errs []error, key_slices []string) error {
         //debug.PrintStack()
+        var is_rdd_way bool = false
+        if (len(key_slices) == 5) {
+          is_rdd_way = true
+          //fmt.Println("#### RDD Get request = ", bucket, object, 
+          //             key_slices[0], key_slices[1], key_slices[2], key_slices[3], key_slices[4])
+        }
 
         if err := checkGetObjArgs(ctx, bucket, object); err != nil {
                 return err
@@ -362,39 +382,35 @@ func (xl xlObjects) getObjectNoMeta(ctx context.Context, bucket, object string, 
           index := int(keyCrc % uint32(len(onlineDisks)))
           disk := onlineDisks[index]
           //fmt.Println(" ### Non EC Read :: ", index, onlineDisks, disk)
-          /*objBuf, err := disk.ReadAll(bucket, object)
-          if err != nil  {
-                if err != errFileNotFound && err != errVolumeNotFound {
-                        logger.GetReqInfo(ctx).AppendTags("disk", disk.String())
-                        logger.LogIf(ctx, err)
-                }
-                fmt.Println("### No EC GET error = ", err, bucket, object)
-                return toObjectErr(err, bucket, object)
-          }
-          if len(objBuf) == 0 {
-                err = errFileNotFound
-                fmt.Println("### No EC zero legth GET error = ", err)
-                return toObjectErr(err, bucket, object)        
-          }
-          _, err = io.Copy(writer, bytes.NewReader(objBuf))
-          if err != nil {
-            // The writer will be closed incase of range queries, which will emit ErrClosedPipe.
-            if err != io.ErrClosedPipe {
-              logger.LogIf(ctx, err)
+          if (is_rdd_way) {
+            remoteAddr,_ := strconv.ParseUint(key_slices[0], 16, 64)
+            remoteValLen,_ := strconv.ParseUint(key_slices[1], 10, 64)
+            rQhandle,_ := strconv.ParseUint(key_slices[2], 16, 64)
+            rKey,_ := strconv.ParseUint(key_slices[3], 16, 64)
+            err_rdd := disk.ReadRDDWay(bucket, object, remoteAddr, remoteValLen, uint32(rKey), uint16(rQhandle))
+            if (err_rdd != nil) {
+              return toObjectErr(err_rdd, bucket, object)
             }
-            return toObjectErr(err, bucket, object) 
-          }*/
+            _, err_rdd = io.Copy(writer, strings.NewReader(etag))
+            if err_rdd != nil {
+              if err_rdd != io.ErrClosedPipe {
+                logger.LogIf(ctx, err_rdd)
+              }
+              return toObjectErr(err_rdd, bucket, object)
 
-          err := disk.ReadAndCopy(bucket, object, writer)
-          if err != nil {
-            // The writer will be closed incase of range queries, which will emit ErrClosedPipe.
-            if err != io.ErrClosedPipe {
-              logger.LogIf(ctx, err)
-            }
+            }    
+          } else {
 
-            return toObjectErr(err, bucket, object)
-          } 
+            err := disk.ReadAndCopy(bucket, object, writer)
+            if err != nil {
+              // The writer will be closed incase of range queries, which will emit ErrClosedPipe.
+              if err != io.ErrClosedPipe {
+                logger.LogIf(ctx, err)
+              }
 
+              return toObjectErr(err, bucket, object)
+            } 
+          }
         }
         // Return success.
         return nil
@@ -639,11 +655,15 @@ func (xl xlObjects) getObjectInfoDir(ctx context.Context, bucket, object string)
 // GetObjectInfo - reads object metadata and replies back ObjectInfo.
 func (xl xlObjects) GetObjectInfo(ctx context.Context, bucket, object string, opts ObjectOptions) (oi ObjectInfo, e error) {
 	// Lock the object before reading.
-	objectLock := xl.nsMutex.NewNSLock(bucket, object)
-	if err := objectLock.GetRLock(globalObjectTimeout); err != nil {
+        //fmt.Println("###GetObjectInfo::", bucket, object)
+        
+        if !globalNolock_read {
+	  objectLock := xl.nsMutex.NewNSLock(bucket, object)
+	  if err := objectLock.GetRLock(globalObjectTimeout); err != nil {
 		return oi, err
-	}
-	defer objectLock.RUnlock()
+	  }
+	  defer objectLock.RUnlock()
+        }
 
 	if err := checkGetObjArgs(ctx, bucket, object); err != nil {
 		return oi, err
@@ -661,6 +681,7 @@ func (xl xlObjects) GetObjectInfo(ctx context.Context, bucket, object string, op
 
 	info, err := xl.getObjectInfo(ctx, bucket, object)
 	if err != nil {
+                fmt.Println("###getObjectInfo failed !!", err)
 		return oi, toObjectErr(err, bucket, object)
 	}
 
@@ -686,6 +707,7 @@ func (xl xlObjects) getObjectInfoVerbose(ctx context.Context, bucket, object str
 
           // Pick latest valid metadata.
           xlMeta, err := pickValidXLMeta(ctx, metaArr, modTime, readQuorum)
+          //fmt.Println("@@@@@@@@@@ xlMeta Read all = ", xlMeta)
           if err != nil {
                 return objInfo, nil, xlMeta, errs, err
           }
@@ -697,6 +719,7 @@ func (xl xlObjects) getObjectInfoVerbose(ctx context.Context, bucket, object str
           index := int(keyCrc % uint32(len(disks)))
           //fmt.Println("## Index for getting meta = ", index, disks[index])
           xlMeta, err := readXLMeta(ctx, disks[index], bucket, object)
+          //fmt.Println("@@@@@@@@@@ xlMeta = ", xlMeta)
           errs := make([]error, len(disks))
           if err != nil {
             errs[index] = err
@@ -720,7 +743,19 @@ func (xl xlObjects) getObjectInfoVerbose(ctx context.Context, bucket, object str
 
 
 // getObjectInfo - wrapper for reading object metadata and constructs ObjectInfo.
-func (xl xlObjects) getObjectInfo(ctx context.Context, bucket, object string) (objInfo ObjectInfo, err error) {
+func (xl xlObjects) getObjectInfo(ctx context.Context, bucket, object_key string) (objInfo ObjectInfo, err error) {
+        //fmt.Println("## getObjectInfo called = ",bucket, object_key)
+        //debug.PrintStack()
+        var object string
+        var is_rdd_way bool = false
+        key_slices := strings.Split(object_key, "-rdd-")
+        if (len(key_slices) == 1) {
+          object = key_slices[0]
+        } else {
+          object = key_slices[4]
+          is_rdd_way = true
+        }
+
 	disks := xl.getDisks()
 
         if (!globalOptimizedMetaReader) {
@@ -740,6 +775,7 @@ func (xl xlObjects) getObjectInfo(ctx context.Context, bucket, object string) (o
 
 	  // Pick latest valid metadata.
 	  xlMeta, err := pickValidXLMeta(ctx, metaArr, modTime, readQuorum)
+          //fmt.Println("@@@@@@@@@@ xlMeta Read all = ", xlMeta)
 	  if err != nil {
 		return objInfo, err
 	  }
@@ -749,8 +785,10 @@ func (xl xlObjects) getObjectInfo(ctx context.Context, bucket, object string) (o
 
           keyCrc := crc32.Checksum([]byte(object), crc32.IEEETable)
           index := int(keyCrc % uint32(len(disks)))
-          //fmt.Println("## Index for getting meta = ", index, disks[index])
+          //fmt.Println("## Index for getting meta = ", index, disks[index], bucket, object)
           xlMeta, err := readXLMeta(ctx, disks[index], bucket, object)
+          //xlMeta.Meta["X-Amz-Meta-Rkey"] = "0x9F56"
+          //fmt.Println("@@@@@@@@@@ xlMeta.meta  = ", xlMeta.Meta, xlMeta.Meta["X-Amz-Meta-Rkey"])
           errs := make([]error, len(disks))
           if err != nil {
             errs[index] = err
@@ -766,8 +804,12 @@ func (xl xlObjects) getObjectInfo(ctx context.Context, bucket, object string) (o
           if err != nil {
                return objInfo, err 
           }
-
+          //objInfo = xlMeta.ToObjectInfo(bucket, object)
+          if (is_rdd_way) {
+            //objInfo.Size = int64(len(objInfo.ETag))
+          }
           return xlMeta.ToObjectInfo(bucket, object), nil
+          //return objInfo, nil
         }
 
 }
@@ -1090,20 +1132,73 @@ func (xl xlObjects) putObject(ctx context.Context, bucket string, object string,
             logger.LogIf(ctx, err)
             return ObjectInfo{}, toObjectErr(err, bucket, object) 
           }
+          
+          if strings.Contains(object, ".dss.rdd.init") {
+            //Its a special put for saving RDD connection handles
+            fmt.Println("RDD connection PUT, key = ", object)
+            obj_slices := strings.Split(object, ".")
+            remote_client_id, _ := strconv.ParseUint(obj_slices[0], 16, 64)
+            str_buffer := string(buffer[:])
+            fmt.Println("RDD connection PUT, value = ", str_buffer)
+            key_slices := strings.Split(str_buffer, "##")
+            fmt.Println("RDD connection PUT, key_slices = ", key_slices)
+            disks := xl.getDisks()
+            if (len(disks) > len(key_slices)) {
+              fmt.Println("Invalid number of RDD Connection handle passed", len(disks), len(key_slices))
+              gIsRDDQHandleSet = false
+              err = errors.New("Invalid RDD param")
+              return ObjectInfo{}, toObjectErr(err, bucket, object)
+           
+            }
+            var num_update int = 0
+            for i := 0; i < len(key_slices); i++ {
+              rdd_params := strings.Split(key_slices[i], "::")
+              fmt.Println("rdd param format", rdd_params)
+              if (len(rdd_params) != 2) {
+                fmt.Println("Invalid rdd param format", rdd_params)
+                gIsRDDQHandleSet = false
+                err = errors.New("Invalid RDD param")
+                return ObjectInfo{}, toObjectErr(err, bucket, object)
+              } else {
+                var num_update uint32 = 0
+                for index := 0; index < len(disks); i++ {
+                  rQhandle,_ := strconv.ParseUint(obj_slices[0], 16, 64)
+                  err = disks[index].AddRDDParam(remote_client_id, rdd_params[0], uint16(rQhandle))
+                  if err == nil {
+                    num_update++
+                    break;
+                  }
+                  
+                }
+              }
+            }
+            if (num_update == 0) {
+              fmt.Println("RDD NQN Id passed is not matching with disk NQNs, can't enable RDD transfer. ")
+              gIsRDDQHandleSet = false
+              err = errors.New("Invalid RDD param")
+              return ObjectInfo{}, toObjectErr(err, bucket, object)
+              
+            }
 
-          disks := xl.getDisks()
-          keyCrc := crc32.Checksum([]byte(object), crc32.IEEETable)
-          index := int(keyCrc % uint32(len(disks)))
-          onlineDisks = make([]StorageAPI, 1)
-          onlineDisks[0] = disks[index]
-          //fmt.Println(" ### Non EC write :: ", n, index, onlineDisks, len(onlineDisks))
-          err = disks[index].WriteAll(bucket, object, buffer[:n])
-          if err != nil {
-            logger.LogIf(ctx, err) 
-            return ObjectInfo{}, toObjectErr(err, bucket, object)
+            if (num_update != len(disks)) {
+              fmt.Println("WARNING: RDD Connection handle is not set for all the disks: ", len(disks), num_update)              
+            }
+            
+          } else {
+            disks := xl.getDisks()
+            keyCrc := crc32.Checksum([]byte(object), crc32.IEEETable)
+            index := int(keyCrc % uint32(len(disks)))
+            onlineDisks = make([]StorageAPI, 1)
+            onlineDisks[0] = disks[index]
+            //fmt.Println(" ### Non EC write :: ", n, index, onlineDisks, len(onlineDisks))
+            err = disks[index].WriteAll(bucket, object, buffer[:n])
+            if err != nil {
+              logger.LogIf(ctx, err) 
+              return ObjectInfo{}, toObjectErr(err, bucket, object)
+            }
+            sizeWritten = int64 (n)
+            writeQuorum = 1
           }
-          sizeWritten = int64 (n)
-          writeQuorum = 1
         }
 	// Save additional erasureMetadata.
 	modTime := UTCNow()

--- a/cmd/xl-v1-object.go
+++ b/cmd/xl-v1-object.go
@@ -155,13 +155,14 @@ func (xl xlObjects) GetObjectNInfo(ctx context.Context, bucket, object string, r
                                    lockType LockType, opts ObjectOptions) (gr *GetObjectReader, err error) {
         //var object string
         var key_slices []string
-
+        var is_rdd_way bool = false
         if (!globalNoRDD) {
           key_slices = strings.Split(object, globalRddSeparator)
           if (len(key_slices) == 1) {
             object = key_slices[0]
           } else {
             object = key_slices[4]
+            is_rdd_way = true
           }
         }
 	var nsUnlocker = func() {}
@@ -210,6 +211,9 @@ func (xl xlObjects) GetObjectNInfo(ctx context.Context, bucket, object string, r
 	//objInfo, err = xl.getObjectInfo(ctx, bucket, object)
 	objInfo, metaArr, xlMeta, errs, err_obj := xl.getObjectInfoVerbose(ctx, bucket, object)
         //fmt.Println("objInfo.UserDefined = " , objInfo.UserDefined)
+        if (is_rdd_way) {
+          objInfo.Size = int64(len(objInfo.ETag))
+        }
 	if err_obj != nil {
 		nsUnlocker()
 		return nil, toObjectErr(err_obj, bucket, object)
@@ -225,7 +229,7 @@ func (xl xlObjects) GetObjectNInfo(ctx context.Context, bucket, object string, r
 	go func() {
 		//err := xl.getObject(ctx, bucket, object, off, length, pw, "", opts)
 		//err := xl.getObjectNoMeta(ctx, bucket, object, off, length, pw, objInfo.ETag, opts, metaArr, xlMeta, errs, key_slices)
-		err := xl.getObjectNoMeta(ctx, bucket, object, off, length, pw, "", opts, metaArr, xlMeta, errs, key_slices)
+		err := xl.getObjectNoMeta(ctx, bucket, object, off, length, pw, objInfo.ETag, opts, metaArr, xlMeta, errs, key_slices)
                 //block := make([]byte, length)
                 //_, err := io.Copy(pw, bytes.NewReader(block))
                 


### PR DESCRIPTION
## Description
This is the pull request of supporting direct RDMA transfer of value buffer to the client during GET by DSS NVMeOF target software bypassing object store. GET request will still be coming to the S3 object store and object store will still be responsible for sending the response back but actual payload will be RDMAd into client memory by then if successful.

## Motivation and Context
To improve End-to-end performance

## Regression
None, it has backward compatibility of sending payload via object store based on GET request format

## How Has This Been Tested?
Tested extensively for performance and functionalities via S3bench, Elbencho. Functionalities like supporting EC and creating RDMA connection in parallel from multiple clients to the same object store is not supported yet. We have tested with a dedicated minio object store end-point to one client and scaled it out with more clients/minio-endpoint pairs

## Types of changes
It is a significant change adding this new feature

## Checklist:
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.