### PR TITLE
Add reusable workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,21 +1,23 @@
-name: Build dss-minio
+name: dss-minio
 on:
+  workflow_dispatch:
   push:
     branches:
       - master
+      - stable/*
   pull_request:
-    types: [opened, synchronize, reopened]
+    branches:
+      - master
+      - stable/*
+    types:
+      - opened
+      - reopened
+      - synchronize
+
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
-      - name: Build dss-minio on CodeBuild
-        uses: aws-actions/aws-codebuild-run-build@v1
-        with:
-          project-name: dss-minio
+  dss-minio:
+    uses: OpenMPDK/DSS/.github/workflows/build-aws.yml@master
+    with:
+      component: dss-minio
+      project-name: OpenMPDK_dss-minio
+    secrets: inherit

--- a/buildspec/dss-minio.yml
+++ b/buildspec/dss-minio.yml
@@ -1,0 +1,31 @@
+version: 0.2
+
+env:
+  secrets-manager:
+    SONAR_TOKEN: Codebuild-DSS:SONAR_TOKEN
+    DSSS3URI: Codebuild-DSS:DSSS3URI
+  variables:
+    DSSGLOBLIST: "dss-minio-bin-*.tgz"
+
+phases:
+  pre_build:
+    commands:
+      - |
+        sonar-scanner \
+          -Dsonar.branch.name="$([[ "$GITHUB_REF_NAME" != *"/merge" ]] && echo "$GITHUB_REF_NAME")" \
+          -Dsonar.pullrequest.key=$(echo $GITHUB_REF | grep -oP "^refs/pull/\K[^/]+") \
+          -Dsonar.pullrequest.base=${GITHUB_BASE_REF} \
+          -Dsonar.pullrequest.branch=${GITHUB_HEAD_REF} \
+      - /getminiodeps.sh
+  build:
+    commands:
+      - ./build.sh
+  post_build:
+    commands:
+      - /stagemergeartifacts.sh
+
+artifacts:
+  files:
+    - dss-minio-bin-*.tgz
+  discard-paths: yes
+  name: builds/dss-minio/$CODEBUILD_BUILD_NUMBER

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+sonar.organization=openmpdk
+sonar.projectKey=OpenMPDK_dss-minio
+sonar.sources=.
+sonar.host.url=https://sonarcloud.io
+sonar.pullrequest.github.summary_comment=true
+sonar.pullrequest.provider=GitHub
+sonar.pullrequest.github.repository=OpenMPDK/dss-minio
+sonar.c.file.suffixes=-
+sonar.cpp.file.suffixes=-
+sonar.objc.file.suffixes=-


### PR DESCRIPTION
Add re-usable workflows to build MinIO and support multi-version branching strategy

## Description
* Added Sonar properties file
* Added GitHub workflow, leveraging reusable workflow from DSS repo, master branch
* Added CodeBuild buildspec

## Motivation and Context
* Enable dss-minio to build using new workflows, which are leveraged by all other DSS repos

## Regression
no

## How Has This Been Tested?
These changes are in-line with changes made to all other DSS repos and have been tested end-to-end in each respective repo.

## Types of changes
n/a

## Checklist:
n/a