### PR TITLE
Update .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ workflow:
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
       variables:
         BRANCH_NAME: $CI_MERGE_REQUEST_TARGET_BRANCH_NAME
-    - if: $CI_COMMIT_BRANCH == "$MINIO_MAIN_BRANCH" && $CI_PIPELINE_SOURCE == "push"
+    - if: $CI_COMMIT_BRANCH == "wip-nkv-minio-improvement" && $CI_PIPELINE_SOURCE == "push"
     - if: $CI_COMMIT_BRANCH =~ /^(stable|feature)\/.*/ && $CI_PIPELINE_SOURCE == "push"
 
 image:


### PR DESCRIPTION
I discovered Gitlab-CI will not evaluate variables in workflow rules, so we need to use branch name as a string.