### PR TITLE
Delete was broken for large object >= 70MB

### DIFF
--- a/cmd/kv-storage.go
+++ b/cmd/kv-storage.go
@@ -1252,9 +1252,9 @@ func (k *KVStorage) DeleteFile(volume string, path string) (err error) {
         var is_meta bool = true
 
         if (globalMetaOptNoStat) {
-          if strings.HasSuffix(nskey, xlMetaJSONFile) || strings.HasSuffix(nskey, "part.1") ||  strings.Contains(nskey, ".minio.sys") {
+          if strings.HasSuffix(nskey, xlMetaJSONFile) || strings.Contains(nskey, "part.") ||  strings.Contains(nskey, ".minio.sys") {
 
-            if (strings.HasSuffix(nskey, "part.1")) {
+            if (strings.Contains(nskey, "part.")) {
               bufp = kvValuePool.Get().(*[]byte)
               defer kvValuePool.Put(bufp)
             } else {


### PR DESCRIPTION
Root cause was a hard coded check on part.1 filename assuming there will be only one part during EC. For bigger object there was multiple parts and the check was causing not to delete other parts. Fixed the check to accommodate any file contain "part."
signed-off-by : <som.roy@samsung.com>

<!--- Provide a general summary of your changes in the Title above -->
Removed hard-coded part.1 check to accommodate multiple parts during delete
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Only unit tested on single minio setup with bigger objects
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.