### PR TITLE
Memory pool support for Replication IO

### DIFF
--- a/cmd/debug-storage.go
+++ b/cmd/debug-storage.go
@@ -188,8 +188,8 @@ func (d *debugStorage) UpdateStats () error {
   return err
 }
 
-func (d *debugStorage) ReadAndCopy(volume string, filePath string, writer io.Writer) (err error) {
-        err = d.s.ReadAndCopy(volume, filePath, writer)
+func (d *debugStorage) ReadAndCopy(volume string, filePath string, writer io.Writer, sizehint int64) (err error) {
+        err = d.s.ReadAndCopy(volume, filePath, writer, sizehint)
         if d.enable {
                 fmt.Printf("%s: ReadAndCopy(%s, %s) (%s)\n", d.path, volume, filePath, errStr(err))
         }

--- a/cmd/erasure-utils.go
+++ b/cmd/erasure-utils.go
@@ -150,7 +150,7 @@ func initRepPool(divFactor int) {
   divFactor = 2 * divFactor
   minSize = globalMaxKVObject/int64 (divFactor)
   for (minSize <= 32768) {
-    midSize = (2 * globalMaxKVObject)/int64 (divFactor)
+    minSize = (2 * globalMaxKVObject)/int64 (divFactor)
   }
   fmt.Println("### Creating Min Rep Pool with object size = ", minSize )
   kvMinPoolRep = &kvMinSizePoolRepPoolType{

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -174,6 +174,7 @@ var (
         globalNotransaction_write bool 
         globalDo_Write_Opt bool
         globalDontUseECMemPool bool 
+        globalDontUseRepMemPool bool 
         globalZeroCopyReader bool 
         globalOptimizedMetaReader bool 
         globalMetaOptNoStat bool 

--- a/cmd/kv.go
+++ b/cmd/kv.go
@@ -364,9 +364,9 @@ var kvPadding bool = os.Getenv("MINIO_NKV_PADDING") != "off"
 var kvMaxValueSize = getKVMaxValueSize()
 
 func getKVMaxValueSize() int {
-	str := os.Getenv("MINIO_NKV_MAX_VALUE_SIZE")
+	str := os.Getenv("MINIO_NKV_MAX_VALUE_SIZE_WITHOUT_RDD")
 	if str == "" {
-		return 2 * 1024 * 1024
+		return 1 * 1024 * 1024
 	}
 	valSize, err := strconv.Atoi(str)
 	logger.FatalIf(err, "parsing MINIO_NKV_MAX_VALUE_SIZE")
@@ -725,7 +725,7 @@ func (k *KV) Put(keyStr string, value []byte) error {
         size := len(value)
 
         if (!globalNoEC || (size > int (globalMaxKVObject))) {
-          max_supported_size = kvMaxValueSize
+          max_supported_size = kvMaxValueSize 
         }
 	if len(value) > max_supported_size {
                 fmt.Println("##### invalid value length during PUT", keyStr, len(value), max_supported_size)
@@ -822,7 +822,7 @@ func (k *KV) Get(keyStr string, value []byte) ([]byte, error) {
         size := len(value)
 
         if (!globalNoEC || (size > int (globalMaxKVObject))) {
-          max_supported_size = kvMaxValueSize
+          max_supported_size = kvMaxValueSize 
         }
         if len(value) > max_supported_size {
                 fmt.Println("##### invalid value length during GET", keyStr, len(value), max_supported_size)

--- a/cmd/posix.go
+++ b/cmd/posix.go
@@ -1410,7 +1410,7 @@ func (s *posix) UpdateStats() error {
   return nil
 }
 
-func (s *posix) ReadAndCopy(volume string, filePath string, writer io.Writer) (err error) {
+func (s *posix) ReadAndCopy(volume string, filePath string, writer io.Writer, sizehint int64) (err error) {
 
   return nil
 }

--- a/cmd/storage-interface.go
+++ b/cmd/storage-interface.go
@@ -57,7 +57,7 @@ type StorageAPI interface {
 
 	// Read all.
 	ReadAll(volume string, path string) (buf []byte, err error)
-	ReadAndCopy(volume string, path string, writer io.Writer) (err error)
+	ReadAndCopy(volume string, path string, writer io.Writer, sizehint int64) (err error)
         ReadRDDWay(volume string, filePath string, remoteAddress uint64, valueLen uint64, rKey uint32, remoteClientId string) (err error)
         AddRDDParam(remoteClientId string, NQNId string, rQhandle uint16) (err error)
 }

--- a/cmd/storage-rest-client.go
+++ b/cmd/storage-rest-client.go
@@ -392,7 +392,7 @@ func (client *storageRESTClient) UpdateStats() error {
   return nil
 }
 
-func (client *storageRESTClient) ReadAndCopy(volume string, filePath string, writer io.Writer) (err error) {
+func (client *storageRESTClient) ReadAndCopy(volume string, filePath string, writer io.Writer, sizehint int64) (err error) {
 
   return nil
 }

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -536,6 +536,31 @@ func newXLSets(endpoints EndpointList, format *formatXLV3, setCount int, drivesP
         fmt.Printf("### RDD Key separator  = %s\n", globalRddSeparator)
 
         globalDummy_read = -1
+
+        globalDontUseRepMemPool = false
+        if os.Getenv("MINIO_DONT_USE_REP_MEM_POOL") != "" {
+          fmt.Println("### Setting up *not to* use Rep mem-pool.. ###")
+          globalDontUseRepMemPool = true
+        }
+
+        if (!globalDontUseRepMemPool) {
+          var divFactor int64
+          fmt.Println("### Setting up to *use* Rep mem-pool.. ###")
+          if v := os.Getenv("MINIO_REP_MEM_POOL_DIV_FACTOR"); v != "" {
+            var err error
+            divFactor, err = strconv.ParseInt(v, 10, 64)
+            if err != nil {
+              fmt.Printf("### Wrong value of MINIO_REP_MEM_POOL_DIV_FACTOR = %s\n", v)
+              divFactor = 4
+            }
+          } else {
+            divFactor = 4
+          }
+          fmt.Println("### Div Factor passed = ###", divFactor)
+
+          initRepPool(int (divFactor))
+        }
+
        
 	return s, nil
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added Memory pool support for Replication IO.

## Description
<!--- Describe your changes in detail -->
Memory pool support for Replication IO. Configurable three different memory pool size and based on the IO size the closest memory pool will be selected. This will enable IO size > 1MB in the DSS Minio KV stack.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To support > 1MB IO in the Minio KV path.
## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit testing with single node setup. Performance tested on single minio with 1MB and 8 MB.
**Disclaimer** because of target issue of supporting large number of bigger IOs, can't stress with more ios in my test.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.