### PR TITLE
Instantaneous BW and IOPS reporting to Prometheus

### DIFF
--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -191,9 +191,21 @@ var (
         globalTotalGetIOCount uint64
         globalIsStopping bool = false
         gIsRDDQHandleSet bool = false
-        globalCurrIOCount uint64
-        globalCurrBW uint64
-        globalMetricsChan = make(chan uint32)
+
+        report_minio_metrics bool = os.Getenv("MINIO_REPORT_METRICS") != ""
+        // Separate counters for live collecting and actual reported
+        // This is to avoid low numbers being reported if Collect is called while metrics thread is recording,
+        // report counters will store the last completed second of metrics
+        globalCurrPutIOPS uint64
+        globalCurrGetIOPS uint64
+        globalCurrPutBW uint64
+        globalCurrGetBW uint64
+        globalCurrDel uint64
+        globalReportPutIOPS uint64
+        globalReportGetIOPS uint64
+        globalReportPutBW uint64
+        globalReportGetBW uint64
+        globalReportDel uint64
         globalCollectMetrics uint32
 
 	// Global server's network statistics

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -190,6 +190,10 @@ var (
         globalTotalGetIOCount uint64
         globalIsStopping bool = false
         gIsRDDQHandleSet bool = false
+		globalCurrIOCount uint64
+		globalCurrBW uint64
+		globalMetricsChan = make(chan uint32)
+		globalCollectMetrics uint32
 
 	// Global server's network statistics
 	globalConnStats = newConnStats()

--- a/cmd/globals.go
+++ b/cmd/globals.go
@@ -191,10 +191,10 @@ var (
         globalTotalGetIOCount uint64
         globalIsStopping bool = false
         gIsRDDQHandleSet bool = false
-		globalCurrIOCount uint64
-		globalCurrBW uint64
-		globalMetricsChan = make(chan uint32)
-		globalCollectMetrics uint32
+        globalCurrIOCount uint64
+        globalCurrBW uint64
+        globalMetricsChan = make(chan uint32)
+        globalCollectMetrics uint32
 
 	// Global server's network statistics
 	globalConnStats = newConnStats()

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -85,7 +85,7 @@ func (c *minioCollector) Collect(ch chan<- prometheus.Metric) {
 			"Current BW of this Minio instance (KiB/s)",
 			nil, nil),
 		prometheus.CounterValue,
-		float64(float64(atomic.LoadUint64(&globalCurrBW)) / float64(1024)),
+		float64(atomic.LoadUint64(&globalCurrBW)),
 	)
 	// Reset counters once reported
 	atomic.StoreUint64(&globalCurrIOCount, 0)

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -82,7 +82,7 @@ func (c *minioCollector) Collect(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(
 		prometheus.NewDesc(
 			prometheus.BuildFQName("minio", "metrics", "bw"),
-			"Current BW of this Minio instance (KiB/s)",
+			"Current BW of this Minio instance",
 			nil, nil),
 		prometheus.CounterValue,
 		float64(atomic.LoadUint64(&globalCurrBW)),

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -41,7 +41,6 @@ var (
 // Couldn't see any difference in functionality
 func init() {
 	prometheus.MustRegister(httpRequestsDuration)
-	//prometheus.MustRegister(newMinioCollector())
 }
 
 // newMinioCollector describes the collector

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -65,30 +65,56 @@ func (c *minioCollector) Describe(ch chan<- *prometheus.Desc) {
 
 // Collect is called by the Prometheus registry when collecting metrics.
 func (c *minioCollector) Collect(ch chan<- prometheus.Metric) {
+    // Only report in Prometheus if MINIO_REPORT_METRICS is set
+    if report_minio_metrics {
+        ch <- prometheus.MustNewConstMetric(
+            prometheus.NewDesc(
+                prometheus.BuildFQName("minio", "metrics", "put_iops"),
+                "Current PUT IOPS of this Minio instance",
+                nil, nil),
+            prometheus.CounterValue,
+            float64(atomic.LoadUint64(&globalReportPutIOPS)),
+        )
+        
+        ch <- prometheus.MustNewConstMetric(
+            prometheus.NewDesc(
+                prometheus.BuildFQName("minio", "metrics", "get_iops"),
+                "Current GET IOPS of this Minio instance",
+                nil, nil),
+            prometheus.CounterValue,
+            float64(atomic.LoadUint64(&globalReportGetIOPS)),
+        )
+    
+        ch <- prometheus.MustNewConstMetric(
+            prometheus.NewDesc(
+                prometheus.BuildFQName("minio", "metrics", "del_iops"),
+                "Current DEL IOPS of this Minio instance",
+                nil, nil),
+            prometheus.CounterValue,
+            float64(atomic.LoadUint64(&globalReportDel)),
+        )
+    
+        ch <- prometheus.MustNewConstMetric(
+            prometheus.NewDesc(
+                prometheus.BuildFQName("minio", "metrics", "put_bw"),
+                "Current PUT BW of this Minio instance",
+                nil, nil),
+            prometheus.CounterValue,
+            float64(atomic.LoadUint64(&globalReportPutBW)),
+        )
+    
+        ch <- prometheus.MustNewConstMetric(
+            prometheus.NewDesc(
+                prometheus.BuildFQName("minio", "metrics", "get_bw"),
+                "Current GET BW of this Minio instance",
+                nil, nil),
+            prometheus.CounterValue,
+            float64(atomic.LoadUint64(&globalReportGetBW)),
+        )
+    }
+	
 
-	globalMetricsChan<- 1
-	// Waiting to make sure metrics thread finishes before
-	<-globalMetricsChan
-	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
-			prometheus.BuildFQName("minio", "metrics", "iops"),
-			"Current IOPS of this Minio instance",
-			nil, nil),
-		prometheus.CounterValue,
-		float64(atomic.LoadUint64(&globalCurrIOCount)),
-	)
 
-	ch <- prometheus.MustNewConstMetric(
-		prometheus.NewDesc(
-			prometheus.BuildFQName("minio", "metrics", "bw"),
-			"Current BW of this Minio instance",
-			nil, nil),
-		prometheus.CounterValue,
-		float64(atomic.LoadUint64(&globalCurrBW)),
-	)
-	// Reset counters once reported
-	atomic.StoreUint64(&globalCurrIOCount, 0)
-	atomic.StoreUint64(&globalCurrBW, 0)
 	
 	// Always expose network stats
 

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -401,6 +401,10 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 	  defer gr.Close()
 
 	  objInfo = gr.ObjInfo
+	  if (atomic.LoadUint32(&globalCollectMetrics) == 1) {
+		atomic.AddUint64(&globalCurrBW, uint64(objInfo.Size))
+		atomic.AddUint64(&globalCurrIOCount, 1)
+	  }
         }
 
 	if objectAPI.IsEncryptionSupported() {
@@ -1417,6 +1421,11 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 	if err != nil {
 		writeErrorResponse(ctx, w, toAPIError(ctx, err), r.URL, guessIsBrowserReq(r))
 		return
+	}
+
+	if atomic.LoadUint32(&globalCollectMetrics) == 1 {
+		atomic.AddUint64(&globalCurrBW, uint64(objInfo.Size))
+		atomic.AddUint64(&globalCurrIOCount, 1)
 	}
 
 	etag := objInfo.ETag

--- a/cmd/object-handlers.go
+++ b/cmd/object-handlers.go
@@ -401,10 +401,10 @@ func (api objectAPIHandlers) GetObjectHandler(w http.ResponseWriter, r *http.Req
 	  defer gr.Close()
 
 	  objInfo = gr.ObjInfo
-	  if (atomic.LoadUint32(&globalCollectMetrics) == 1) {
-		atomic.AddUint64(&globalCurrBW, uint64(objInfo.Size))
-		atomic.AddUint64(&globalCurrIOCount, 1)
-	  }
+            if (atomic.LoadUint32(&globalCollectMetrics) == 1) {
+                atomic.AddUint64(&globalCurrBW, uint64(objInfo.Size))
+                atomic.AddUint64(&globalCurrIOCount, 1)
+            }
         }
 
 	if objectAPI.IsEncryptionSupported() {
@@ -1423,10 +1423,10 @@ func (api objectAPIHandlers) PutObjectHandler(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if atomic.LoadUint32(&globalCollectMetrics) == 1 {
-		atomic.AddUint64(&globalCurrBW, uint64(objInfo.Size))
-		atomic.AddUint64(&globalCurrIOCount, 1)
-	}
+    if atomic.LoadUint32(&globalCollectMetrics) == 1 {
+        atomic.AddUint64(&globalCurrBW, uint64(objInfo.Size))
+        atomic.AddUint64(&globalCurrIOCount, 1)
+    }
 
 	etag := objInfo.ETag
 	if objInfo.IsCompressed() {

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -357,13 +357,24 @@ func metricsReporting() {
         // Go 1.12 doesn't have atomic structs (Go 1.19 introduced atomic structs)
 
         // Signal to start recording IO, then sleep for 1s and report the counters
-        start := <-globalMetricsChan
-        atomic.StoreUint32(&globalCollectMetrics, start)
+        atomic.StoreUint32(&globalCollectMetrics, 1)
         
         time.Sleep(1 * time.Second)
         atomic.StoreUint32(&globalCollectMetrics, 0)
         // Signal to stop after collecting for 1s
-        globalMetricsChan <- 0
+
+        // Record counters to a variable for Prometheus to report
+        atomic.StoreUint64(&globalReportPutIOPS, atomic.LoadUint64(&globalCurrPutIOPS))
+        atomic.StoreUint64(&globalReportGetIOPS, atomic.LoadUint64(&globalCurrGetIOPS))
+        atomic.StoreUint64(&globalReportPutBW, atomic.LoadUint64(&globalCurrPutBW))
+        atomic.StoreUint64(&globalReportGetBW, atomic.LoadUint64(&globalCurrGetBW))
+        atomic.StoreUint64(&globalReportDel, atomic.LoadUint64(&globalCurrDel))
+        // Reset counters after recording the last second of metrics
+        atomic.StoreUint64(&globalCurrPutIOPS, 0)
+        atomic.StoreUint64(&globalCurrGetIOPS, 0)
+        atomic.StoreUint64(&globalCurrPutBW, 0)
+        atomic.StoreUint64(&globalCurrGetBW, 0)
+        atomic.StoreUint64(&globalCurrDel, 0)
     }
 }
 
@@ -642,7 +653,10 @@ func newXLSets(endpoints EndpointList, format *formatXLV3, setCount int, drivesP
           go s.UpdateCountersToDisk()
         }
 
-        go metricsReporting()
+        // Only record metrics if MINIO_REPORT_METRICS env variable is set
+        if (report_minio_metrics) {
+            go metricsReporting()
+        }
 
         globalSC_read = false
         if os.Getenv("MINIO_ENABLE_SC_READ") != "" {

--- a/cmd/xl-sets.go
+++ b/cmd/xl-sets.go
@@ -350,21 +350,21 @@ func (s *xlSets) UpdateCountersToDisk() {
 }
 // BW/IOPS reporting thread
 func metricsReporting() {
-	fmt.Println("### Metrics reporting thread started")
-	for {
-		// Need to use atomic operation for setting and checking whether to collect
-		// It's probably fine to not use atomic within this thread, but IO threads will need it accurately determine whether to record
-		// Go 1.12 doesn't have atomic structs (Go 1.19 introduced atomic structs)
+    fmt.Println("### Metrics reporting thread started")
+    for {
+        // Need to use atomic operation for setting and checking whether to collect
+        // It's probably fine to not use atomic within this thread, but IO threads will need it accurately determine whether to record
+        // Go 1.12 doesn't have atomic structs (Go 1.19 introduced atomic structs)
 
-		// Signal to start recording IO, then sleep for 1s and report the counters
-		start := <-globalMetricsChan
-		atomic.StoreUint32(&globalCollectMetrics, start)
-		
-		time.Sleep(1 * time.Second)
-		atomic.StoreUint32(&globalCollectMetrics, 0)
-		// Signal to stop after collecting for 1s
-		globalMetricsChan <- 0
-	}
+        // Signal to start recording IO, then sleep for 1s and report the counters
+        start := <-globalMetricsChan
+        atomic.StoreUint32(&globalCollectMetrics, start)
+        
+        time.Sleep(1 * time.Second)
+        atomic.StoreUint32(&globalCollectMetrics, 0)
+        // Signal to stop after collecting for 1s
+        globalMetricsChan <- 0
+    }
 }
 
 
@@ -642,7 +642,7 @@ func newXLSets(endpoints EndpointList, format *formatXLV3, setCount int, drivesP
           go s.UpdateCountersToDisk()
         }
 
-		go metricsReporting()
+        go metricsReporting()
 
         globalSC_read = false
         if os.Getenv("MINIO_ENABLE_SC_READ") != "" {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added instantaneous BW and IOPS for Prometheus to collect when called. Current implementation is by having a go routine that will block on a channel until Prometheus collector is called, then signal to IO threads to record IO. The metrics thread will wait 1 second then signal to stop recording and report the number of IO that happened in that 1 second to Prometheus collector.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For management plane to see bandwidth and IOPS; we have no implementation of this currently.

## Regression
<!-- Is this PR fixing a regression? (Yes / No) -->
<!-- If Yes, optionally please include minio version or commit id or PR# that caused this regression, if you have these details. -->
No

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran Elbencho and s3-benchmark then signaled Prometheus to collect and compared Prometheus output to reported BW/IOPS. Mostly relied on Elbencho for this, since it has live output feature that makes it easier to compare real-time stats.

**Example Elbencho vs Promtheus output**
Elbencho:
```
Phase: READ  CPU:  52%  Active: 32  Elapsed: 10s
 Rank   %    DoneMiB      MiB/s       IOPS      Files    Files/s
Total   7      12414       1301       1301      12414       1301
```
Prometheus BW/IOPS reported at about the same time:
```
# HELP minio_metrics_bw Current BW of this Minio instance (KiB/s)
# TYPE minio_metrics_bw counter
minio_metrics_bw 1.32096e+06
# HELP minio_metrics_iops Current IOPS of this Minio instance
# TYPE minio_metrics_iops counter
minio_metrics_iops 1290
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added unit tests to cover my changes.
- [ ] I have added/updated functional tests in [mint](https://github.com/minio/mint). (If yes, add `mint` PR # here: )
- [ ] All new and existing tests passed.